### PR TITLE
updated incorrect jurisdiction

### DIFF
--- a/src/main/resources/mocks/courtsAndHearingsCount.json
+++ b/src/main/resources/mocks/courtsAndHearingsCount.json
@@ -770,7 +770,7 @@
   {
     "courtId": 283,
     "location": "North West",
-    "jurisdiction": "Magistrates' Court",
+    "jurisdiction": "Crown Court",
     "name": "Liverpool Crown Court"
   },
   {


### PR DESCRIPTION
### Change description ###
the court name for liverpool does not match its jurisdiction, changed jurisdiction from mags court to crown court to match the name of the court


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
