### PR TITLE
PUB-000 - Updated version of log4j to 2.15 (Pre-release)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,3 +207,5 @@ rootProject.tasks.named("processSmokeTestResources") {
 wrapper {
   distributionType = Wrapper.DistributionType.ALL
 }
+
+ext['log4j2.version'] = '2.15.0'

--- a/src/main/resources/mocks/courtsAndHearingsCount.json
+++ b/src/main/resources/mocks/courtsAndHearingsCount.json
@@ -770,7 +770,7 @@
   {
     "courtId": 283,
     "location": "North West",
-    "jurisdiction": "Magistrates' Court",
+    "jurisdiction": "Crown Court",
     "name": "Liverpool Crown Court"
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Updated version of log4j to 2.15.0 following vulnerability in library

See https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot for details.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
