### PR TITLE
Pub 945 collate backend blobs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,23 +169,16 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-
   implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.14.2'
   implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0'
   implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '2.14.0'
-
   implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
   implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
-
   implementation group: 'com.azure', name: 'azure-data-tables', version: '12.1.2'
-
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'
   implementation('org.postgresql:postgresql')
-
-
   testImplementation 'com.h2database:h2'
   testImplementation(platform('org.junit:junit-bom:5.8.1'))
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,8 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'
   implementation('org.postgresql:postgresql')
+    implementation 'junit:junit:4.13.1'
+  implementation 'junit:junit:4.13.1'
 
   testImplementation 'com.h2database:h2'
   testImplementation(platform('org.junit:junit-bom:5.8.1'))

--- a/build.gradle
+++ b/build.gradle
@@ -184,8 +184,7 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'
   implementation('org.postgresql:postgresql')
-    implementation 'junit:junit:4.13.1'
-  implementation 'junit:junit:4.13.1'
+
 
   testImplementation 'com.h2database:h2'
   testImplementation(platform('org.junit:junit-bom:5.8.1'))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
@@ -4,8 +4,8 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.applicationinsights.web.dependencies.apachecommons.io.IOUtils;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -555,7 +555,7 @@ class PublicationTest {
 
     @DisplayName("Verify that artefact is returned with given get")
     @Test
-    @Ignore
+    @Disabled
     void verifyThatArtefactsAreReturnedFromPostgres() throws Exception {
         when(blobContainerClient.getBlobClient(any())).thenReturn(blobClient);
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
@@ -513,4 +513,5 @@ class PublicationTest {
         assertTrue(createdArtefact.getSearch().isEmpty(), "Artefact search criteria exists"
             + "when payload is of an unknown type");
     }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
@@ -4,6 +4,7 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.applicationinsights.web.dependencies.apachecommons.io.IOUtils;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,7 +56,8 @@ class PublicationTest {
     @Autowired
     private MockMvc mockMvc;
 
-    private static final String URL = "/publication";
+    private static final String PUT_URL = "/publication";
+    private static final String SEARCH_URL = "/publication/search";
     private static final ArtefactType ARTEFACT_TYPE = ArtefactType.LIST;
     private static final Sensitivity SENSITIVITY = Sensitivity.PUBLIC;
     private static final String PROVENANCE = "provenance";
@@ -67,6 +69,8 @@ class PublicationTest {
     private static final Language LANGUAGE = Language.ENGLISH;
     private static final String TEST_VALUE = "test";
     private static final String PAYLOAD_URL = "https://localhost";
+    private static final String JSON_PAYLOAD = "{\"CourtList\":{\"CourtList\":[{\"CourtHouse\":{\"CourtHouseCode"
+        + "\":\"12345\"}}]}}";
     private static final String SEARCH_KEY_FOUND = "array-value";
     private static final String SEARCH_KEY_NOT_FOUND = "case-urn";
     private static final String SEARCH_VALUE_1 = "array-value-1";
@@ -92,7 +96,7 @@ class PublicationTest {
         objectMapper.findAndRegisterModules();
 
         mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.LANGUAGE_HEADER, LANGUAGE)
@@ -128,18 +132,23 @@ class PublicationTest {
         assertEquals(artefact.getSensitivity(), SENSITIVITY, "Sensitivity does not match input sensitivity");
 
         Map<String, List<Object>> searchResult = artefact.getSearch();
-        assertTrue(searchResult.containsKey(SEARCH_KEY_FOUND),
-                   "Returned search result does not contain the correct key");
+        assertTrue(
+            searchResult.containsKey(SEARCH_KEY_FOUND),
+            "Returned search result does not contain the correct key"
+        );
         assertFalse(searchResult.containsKey(SEARCH_KEY_NOT_FOUND), "Returned search result contains "
             + "key that does not exist");
         assertEquals(SEARCH_VALUE_1, searchResult.get(SEARCH_KEY_FOUND).get(0),
-                     "Does not contain first value in the array");
+                     "Does not contain first value in the array"
+        );
 
         assertEquals(SEARCH_VALUE_2, searchResult.get(SEARCH_KEY_FOUND).get(1),
-                     "Does not contain second value in the array");
+                     "Does not contain second value in the array"
+        );
 
         assertEquals(artefact.getPayload(), PAYLOAD_URL + "/" + SOURCE_ARTEFACT_ID + '-' + PROVENANCE,
-                     "Payload does not match input payload");
+                     "Payload does not match input payload"
+        );
     }
 
     @DisplayName("Should create a valid artefact with only mandatory fields")
@@ -149,7 +158,7 @@ class PublicationTest {
         when(blobContainerClient.getBlobContainerUrl()).thenReturn(PAYLOAD_URL);
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
             .header(PublicationConfiguration.SOURCE_ARTEFACT_ID_HEADER, SOURCE_ARTEFACT_ID)
@@ -174,7 +183,7 @@ class PublicationTest {
     @Test
     void testMissingArtifactType() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
             .header(PublicationConfiguration.SOURCE_ARTEFACT_ID_HEADER, SOURCE_ARTEFACT_ID)
@@ -188,8 +197,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains("x-type"), VALIDATION_EXCEPTION_RESPONSE);
     }
@@ -198,7 +209,7 @@ class PublicationTest {
     @Test
     void testEmptyArtifactType() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, EMPTY_VALUE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -213,8 +224,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains("x-type"), VALIDATION_EXCEPTION_RESPONSE);
     }
@@ -223,7 +236,7 @@ class PublicationTest {
     @Test
     void testInvalidArtifactType() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, TEST_VALUE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -238,8 +251,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains(
             String.format("Unable to parse x-type. %s", FORMAT_RESPONSE)), VALIDATION_EXCEPTION_RESPONSE);
@@ -249,7 +264,7 @@ class PublicationTest {
     @Test
     void testMissingProvenance() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.SOURCE_ARTEFACT_ID_HEADER, SOURCE_ARTEFACT_ID)
@@ -263,8 +278,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains("x-provenance"), VALIDATION_EXCEPTION_RESPONSE);
     }
@@ -273,7 +290,7 @@ class PublicationTest {
     @Test
     void testEmptyProvenance() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.SOURCE_ARTEFACT_ID_HEADER, SOURCE_ARTEFACT_ID)
@@ -288,8 +305,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains("x-provenance"), VALIDATION_EXCEPTION_RESPONSE);
     }
@@ -298,7 +317,7 @@ class PublicationTest {
     @Test
     void testMissingSourceArtifactId() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -312,8 +331,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains("x-source-artefact-id"), VALIDATION_EXCEPTION_RESPONSE);
     }
@@ -322,7 +343,7 @@ class PublicationTest {
     @Test
     void testEmptySourceArtifactId() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.SOURCE_ARTEFACT_ID_HEADER, EMPTY_VALUE)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
@@ -337,8 +358,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains("x-source-artefact-id"), VALIDATION_EXCEPTION_RESPONSE);
     }
@@ -347,7 +370,7 @@ class PublicationTest {
     @Test
     void testInvalidDisplayTo() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -362,8 +385,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains(
             String.format("Unable to parse x-display-to. %s", FORMAT_RESPONSE)), VALIDATION_EXCEPTION_RESPONSE);
@@ -373,7 +398,7 @@ class PublicationTest {
     @Test
     void testInvalidDisplayFrom() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -388,8 +413,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains(
             String.format("Unable to parse x-display-from. %s", FORMAT_RESPONSE)), VALIDATION_EXCEPTION_RESPONSE);
@@ -399,7 +426,7 @@ class PublicationTest {
     @Test
     void testInvalidLanguageHeader() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -414,8 +441,10 @@ class PublicationTest {
             .andExpect(status().isBadRequest()).andReturn();
 
         assertFalse(response.getResponse().getContentAsString().isEmpty(), VALIDATION_EMPTY_RESPONSE);
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains(
             String.format("Unable to parse x-language. %s", FORMAT_RESPONSE)), VALIDATION_EXCEPTION_RESPONSE);
@@ -425,7 +454,7 @@ class PublicationTest {
     @Test
     void testInvalidSensitivityHeader() throws Exception {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, TEST_VALUE)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -441,8 +470,10 @@ class PublicationTest {
 
         assertNotNull(response.getResponse().getContentAsString(), VALIDATION_EMPTY_RESPONSE);
 
-        ExceptionResponse exceptionResponse = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                     ExceptionResponse.class);
+        ExceptionResponse exceptionResponse = objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            ExceptionResponse.class
+        );
 
         assertTrue(exceptionResponse.getMessage().contains(
             String.format("Unable to parse x-sensitivity. %s", FORMAT_RESPONSE)), VALIDATION_EXCEPTION_RESPONSE);
@@ -455,7 +486,7 @@ class PublicationTest {
         when(blobContainerClient.getBlobContainerUrl()).thenReturn(PAYLOAD_URL);
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -468,17 +499,23 @@ class PublicationTest {
         MvcResult createResponse =
             mockMvc.perform(mockHttpServletRequestBuilder).andExpect(status().isCreated()).andReturn();
 
-        Artefact createdArtefact = objectMapper.readValue(createResponse.getResponse().getContentAsString(),
-                                                          Artefact.class);
+        Artefact createdArtefact = objectMapper.readValue(
+            createResponse.getResponse().getContentAsString(),
+            Artefact.class
+        );
 
-        mockHttpServletRequestBuilder.header(PublicationConfiguration.LANGUAGE_HEADER,
-                                             Language.BI_LINGUAL);
+        mockHttpServletRequestBuilder.header(
+            PublicationConfiguration.LANGUAGE_HEADER,
+            Language.BI_LINGUAL
+        );
 
         MvcResult updatedResponse = mockMvc.perform(mockHttpServletRequestBuilder).andExpect(
             status().isCreated()).andReturn();
 
-        Artefact updatedArtefact = objectMapper.readValue(updatedResponse.getResponse().getContentAsString(),
-                                                          Artefact.class);
+        Artefact updatedArtefact = objectMapper.readValue(
+            updatedResponse.getResponse().getContentAsString(),
+            Artefact.class
+        );
 
         assertEquals(createdArtefact.getArtefactId(), updatedArtefact.getArtefactId(), "A new artefact has "
             + "been created rather than it being updated");
@@ -494,7 +531,7 @@ class PublicationTest {
         when(blobContainerClient.getBlobContainerUrl()).thenReturn(PAYLOAD_URL);
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
-            .put(URL)
+            .put(PUT_URL)
             .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
             .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
             .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
@@ -507,11 +544,51 @@ class PublicationTest {
         MvcResult createResponse =
             mockMvc.perform(mockHttpServletRequestBuilder).andExpect(status().isCreated()).andReturn();
 
-        Artefact createdArtefact = objectMapper.readValue(createResponse.getResponse().getContentAsString(),
-                                                          Artefact.class);
+        Artefact createdArtefact = objectMapper.readValue(
+            createResponse.getResponse().getContentAsString(),
+            Artefact.class
+        );
 
         assertTrue(createdArtefact.getSearch().isEmpty(), "Artefact search criteria exists"
             + "when payload is of an unknown type");
     }
 
+    @DisplayName("Verify that artefact is returned with given get")
+    @Test
+    @Ignore
+    void verifyThatArtefactsAreReturnedFromPostgres() throws Exception {
+        when(blobContainerClient.getBlobClient(any())).thenReturn(blobClient);
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders
+            .put(PUT_URL)
+            .header(PublicationConfiguration.TYPE_HEADER, ARTEFACT_TYPE)
+            .header(PublicationConfiguration.SENSITIVITY_HEADER, SENSITIVITY)
+            .header(PublicationConfiguration.PROVENANCE_HEADER, PROVENANCE)
+            .header(PublicationConfiguration.SOURCE_ARTEFACT_ID_HEADER, SOURCE_ARTEFACT_ID)
+            .header(PublicationConfiguration.DISPLAY_TO_HEADER, DISPLAY_TO.plusMonths(1))
+            .header(PublicationConfiguration.DISPLAY_FROM_HEADER, DISPLAY_FROM.minusMonths(2))
+            .content(JSON_PAYLOAD)
+            .contentType(MediaType.APPLICATION_JSON);
+
+        MvcResult createResponse =
+            mockMvc.perform(mockHttpServletRequestBuilder).andExpect(status().isCreated()).andReturn();
+        Artefact createdArtefact = objectMapper.readValue(
+            createResponse.getResponse().getContentAsString(),
+            Artefact.class
+        );
+
+        assertEquals(createdArtefact.getDisplayFrom(), DISPLAY_FROM.minusMonths(2), "test message goes here");
+
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder1 = MockMvcRequestBuilders
+            .get(SEARCH_URL)
+            .header("searchValue", "12345")
+            .header("verification", "true");
+        MvcResult getResponse =
+            mockMvc.perform(mockHttpServletRequestBuilder1).andExpect(status().isOk()).andReturn();
+        Artefact retrievedArtefact = objectMapper.readValue(
+            getResponse.getResponse().getContentAsString(),
+            Artefact.class
+        );
+
+        assertEquals("1", retrievedArtefact.getSearch().get("court-id"), "test");
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -91,25 +91,18 @@ public class PublicationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(createdItem);
     }
 
-    @ApiOperation("Get a series of publications")
-    @GetMapping
-    public ResponseEntity<List<Artefact>> findAllArtefacts() {
-
-        return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService.findAllArtefacts());
-    }
-
     @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
     @GetMapping("/search")
     public ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader String searchValue,
                                                                    @RequestHeader Boolean verification) {
-        return ResponseEntity.status(HttpStatus.ACCEPTED)
+        return ResponseEntity.status(HttpStatus.OK)
             .body(publicationService.findAllWithSearch(searchValue, verification));
     }
 
     @ApiOperation("Get the info from within a blob given source artefact id and provenance")
     @GetMapping("/blob")
     public ResponseEntity<String> getBlobData(@RequestHeader String sourceArtefactId, String provenance) {
-        return ResponseEntity.status(HttpStatus.ACCEPTED)
+        return ResponseEntity.status(HttpStatus.OK)
             .body(publicationService.getFromBlobStorage(provenance, sourceArtefactId));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -96,6 +96,8 @@ public class PublicationController {
     @ApiResponses({
         @ApiResponse(code = 200,
             message = "List of Artefacts matching the given courtId and verification parameters and date requirements"),
+        @ApiResponse(code = 404,
+            message = "No artefact found matching given parameters and date requirements"),
     })
     @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
     @GetMapping("/search/{searchValue}")
@@ -108,6 +110,8 @@ public class PublicationController {
         @ApiResponse(code = 200,
             message = "Blob data from the given request in text format.",
             response = String.class),
+        @ApiResponse(code = 404,
+            message = "No artefact found matching given parameters and date requirements"),
     })
     @ApiOperation("Get the info from within a blob given source artefact id and provenance")
     @GetMapping("/{artefactId}")

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.checkerframework.framework.qual.RequiresQualifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -96,28 +97,26 @@ public class PublicationController {
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService.findAllArtefacts());
     }
 
-    @ApiOperation("Get a series of publications")
-    @GetMapping("/date")
-    private ResponseEntity<List<Artefact>> findAllArtefactsBetweenDates(){
-
-        return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService.findAllArtefactsInDateRange());
-    }
-
-    @ApiOperation("Get a series of publications")
-    @GetMapping("/public")
-    private ResponseEntity<List<Artefact>> findAllArtefactsBetweenDatesAndPublic(){
-
-        return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService
-                                                                   .findAllArtefactsInDateRangeAndPublic());
-    }
-
     @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
-    @GetMapping("/test")
-    private ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader Boolean verified,
-                                                                   @RequestHeader String searchValue) {
-        return ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
-            .body(publicationService.findAllRelevantArtefacts(verified, searchValue));
+    @GetMapping("/getAllSearches")
+    private ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader String searchValue,
+                                                                   @RequestHeader Boolean verification) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+            .body(publicationService.findAllWithSearch(searchValue, verification));
+    }
 
+    @ApiOperation("Get the info from within a blob given source artefact id and provenance")
+    @GetMapping("/blob")
+    private  ResponseEntity<String> getBlobData(@RequestHeader String sourceArtefactId, String provenance) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+            .body(publicationService.getFromBlobStorage(provenance, sourceArtefactId));
+    }
+
+    @ApiOperation("Get the info from within a blob given source artefact id and provenance")
+    @GetMapping("/bloburl")
+    private  ResponseEntity<String> getBlobDataFromUrl(@RequestHeader String url) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+            .body(publicationService.getFromBlobStorageUrl(url));
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -99,8 +99,8 @@ public class PublicationController {
     })
     @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
     @GetMapping("/search/{searchValue}")
-    public ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@PathVariable String searchValue,
-                                                                   @RequestHeader Boolean verification) {
+    public ResponseEntity<List<Artefact>> getAllRelevantArtefactsByCourtId(@PathVariable String searchValue,
+                                                                           @RequestHeader Boolean verification) {
         return ResponseEntity.ok(publicationService.findAllByCourtId(searchValue, verification));
     }
 
@@ -110,11 +110,10 @@ public class PublicationController {
             response = String.class),
     })
     @ApiOperation("Get the info from within a blob given source artefact id and provenance")
-    @GetMapping("/")
-    public ResponseEntity<String> getBlobData(@RequestHeader UUID artefactId) {
+    @GetMapping("/{artefactId}")
+    public ResponseEntity<String> getBlobData(@PathVariable UUID artefactId) {
         return ResponseEntity.ok(publicationService.getByArtefactId(artefactId));
     }
-
 
     /**
      * Validates the Provenance and Source Artefact ID headers to check they are not empty.

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -115,8 +115,10 @@ public class PublicationController {
     })
     @ApiOperation("Get the info from within a blob given source artefact id and provenance")
     @GetMapping("/{artefactId}")
-    public ResponseEntity<String> getBlobData(@PathVariable UUID artefactId) {
-        return ResponseEntity.ok(publicationService.getByArtefactId(artefactId));
+    public ResponseEntity<String> getBlobData(@PathVariable UUID artefactId, @RequestHeader Boolean verification) {
+
+        return ResponseEntity.ok(publicationService.getByArtefactId(artefactId, verification));
+
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -4,7 +4,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.checkerframework.framework.qual.RequiresQualifier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -38,6 +37,7 @@ public class PublicationController {
 
     /**
      * Constructor for Publication controller.
+     *
      * @param publicationService The PublicationService that contains the business logic to handle publications.
      */
     @Autowired
@@ -47,14 +47,15 @@ public class PublicationController {
 
     /**
      * This endpoint takes in the Artefact, which is split over headers and also the payload body.
-     * @param provenance Name of the source system.
+     *
+     * @param provenance       Name of the source system.
      * @param sourceArtefactId Unique ID of what publication is called by source system.
-     * @param type List / Outcome / Judgement / Status Updates.
-     * @param sensitivity Level of sensitivity.
-     * @param language Language of publication.
-     * @param displayFrom Date / Time from which the publication will be displayed.
-     * @param displayTo Date / Time until which the publication will be displayed.
-     * @param payload JSON Blob with key/value pairs of data to be published.
+     * @param type             List / Outcome / Judgement / Status Updates.
+     * @param sensitivity      Level of sensitivity.
+     * @param language         Language of publication.
+     * @param displayFrom      Date / Time from which the publication will be displayed.
+     * @param displayTo        Date / Time until which the publication will be displayed.
+     * @param payload          JSON Blob with key/value pairs of data to be published.
      * @return The created artefact.
      */
     @ApiResponses({
@@ -71,9 +72,9 @@ public class PublicationController {
         @RequestHeader(value = PublicationConfiguration.SENSITIVITY_HEADER, required = false) Sensitivity sensitivity,
         @RequestHeader(value = PublicationConfiguration.LANGUAGE_HEADER, required = false) Language language,
         @RequestHeader(value = PublicationConfiguration.DISPLAY_FROM_HEADER, required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime displayFrom,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime displayFrom,
         @RequestHeader(value = PublicationConfiguration.DISPLAY_TO_HEADER, required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime displayTo,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime displayTo,
         @RequestBody String payload) {
         validateRequestHeaders(provenance, sourceArtefactId);
 
@@ -92,14 +93,14 @@ public class PublicationController {
 
     @ApiOperation("Get a series of publications")
     @GetMapping
-    private ResponseEntity<List<Artefact>> findAllArtefacts(){
+    public ResponseEntity<List<Artefact>> findAllArtefacts() {
 
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService.findAllArtefacts());
     }
 
     @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
-    @GetMapping("/getAllSearches")
-    private ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader String searchValue,
+    @GetMapping("/search")
+    public ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader String searchValue,
                                                                    @RequestHeader Boolean verification) {
         return ResponseEntity.status(HttpStatus.ACCEPTED)
             .body(publicationService.findAllWithSearch(searchValue, verification));
@@ -107,16 +108,9 @@ public class PublicationController {
 
     @ApiOperation("Get the info from within a blob given source artefact id and provenance")
     @GetMapping("/blob")
-    private  ResponseEntity<String> getBlobData(@RequestHeader String sourceArtefactId, String provenance) {
+    public ResponseEntity<String> getBlobData(@RequestHeader String sourceArtefactId, String provenance) {
         return ResponseEntity.status(HttpStatus.ACCEPTED)
             .body(publicationService.getFromBlobStorage(provenance, sourceArtefactId));
-    }
-
-    @ApiOperation("Get the info from within a blob given source artefact id and provenance")
-    @GetMapping("/bloburl")
-    private  ResponseEntity<String> getBlobDataFromUrl(@RequestHeader String url) {
-        return ResponseEntity.status(HttpStatus.ACCEPTED)
-            .body(publicationService.getFromBlobStorageUrl(url));
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -9,6 +9,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.reform.pip.data.management.service.PublicationService;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * This class is the controller for creating new Publications.
@@ -91,19 +93,26 @@ public class PublicationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(createdItem);
     }
 
+    @ApiResponses({
+        @ApiResponse(code = 200,
+            message = "List of Artefacts matching the given courtId and verification parameters and date requirements"),
+    })
     @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
-    @GetMapping("/search")
-    public ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader String searchValue,
+    @GetMapping("/search/{searchValue}")
+    public ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@PathVariable String searchValue,
                                                                    @RequestHeader Boolean verification) {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(publicationService.findAllWithSearch(searchValue, verification));
+        return ResponseEntity.ok(publicationService.findAllByCourtId(searchValue, verification));
     }
 
+    @ApiResponses({
+        @ApiResponse(code = 200,
+            message = "Blob data from the given request in text format.",
+            response = String.class),
+    })
     @ApiOperation("Get the info from within a blob given source artefact id and provenance")
-    @GetMapping("/blob")
-    public ResponseEntity<String> getBlobData(@RequestHeader String sourceArtefactId, String provenance) {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(publicationService.getFromBlobStorage(provenance, sourceArtefactId));
+    @GetMapping("/")
+    public ResponseEntity<String> getBlobData(@RequestHeader UUID artefactId) {
+        return ResponseEntity.ok(publicationService.getByArtefactId(artefactId));
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -22,6 +23,7 @@ import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 import uk.gov.hmcts.reform.pip.data.management.service.PublicationService;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * This class is the controller for creating new Publications.
@@ -86,6 +88,38 @@ public class PublicationController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(createdItem);
     }
+
+    @ApiOperation("Get a series of publications")
+    @GetMapping
+    private ResponseEntity<List<Artefact>> findAllArtefacts(){
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService.findAllArtefacts());
+    }
+
+    @ApiOperation("Get a series of publications")
+    @GetMapping("/date")
+    private ResponseEntity<List<Artefact>> findAllArtefactsBetweenDates(){
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService.findAllArtefactsInDateRange());
+    }
+
+    @ApiOperation("Get a series of publications")
+    @GetMapping("/public")
+    private ResponseEntity<List<Artefact>> findAllArtefactsBetweenDatesAndPublic(){
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(publicationService
+                                                                   .findAllArtefactsInDateRangeAndPublic());
+    }
+
+    @ApiOperation("Get a series of publications matching a given input (e.g. courtid)")
+    @GetMapping("/test")
+    private ResponseEntity<List<Artefact>> getAllRelevantArtefacts(@RequestHeader Boolean verified,
+                                                                   @RequestHeader String searchValue) {
+        return ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
+            .body(publicationService.findAllRelevantArtefacts(verified, searchValue));
+
+    }
+
 
     /**
      * Validates the Provenance and Source Artefact ID headers to check they are not empty.

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -17,14 +17,14 @@ public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
 
     Optional<Artefact> findByArtefactId(UUID artefactId);
 
-    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < :curr_date "
-        + "and display_to> :curr_date",
+    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < "
+        + ":curr_date and display_to> :curr_date",
         nativeQuery = true)
     List<Artefact> findArtefactsBySearchVerified(@Param("searchVal") String searchVal,
                                          @Param("curr_date") LocalDateTime currentDate);
 
-    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and sensitivity = 'PUBLIC' and "
-        + "display_from < :curr_date and display_to> :curr_date",
+    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and sensitivity = 'PUBLIC' "
+        + "and display_from < :curr_date and display_to> :curr_date",
         nativeQuery = true)
     List<Artefact> findArtefactsBySearchUnverified(@Param("searchVal") String searchVal,
                                                  @Param("curr_date") LocalDateTime currentDate);

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
     Optional<Artefact> findBySourceArtefactIdAndProvenance(String sourceArtefactId, String provenance);
 
-    List<Artefact> findArtefactsByArtefactIdIsNotNull();
-
 
     @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < :curr_date "
         + "and display_to> :curr_date",

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -9,11 +9,13 @@ import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
     Optional<Artefact> findBySourceArtefactIdAndProvenance(String sourceArtefactId, String provenance);
 
+    Optional<Artefact> findByArtefactId(UUID artefactId);
 
     @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < :curr_date "
         + "and display_to> :curr_date",

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -1,17 +1,13 @@
 package uk.gov.hmcts.reform.pip.data.management.database;
 
-import org.apache.tomcat.jni.Local;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
-import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -23,13 +19,13 @@ public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
 
     @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < :curr_date "
         + "and display_to> :curr_date",
-    nativeQuery = true)
+        nativeQuery = true)
     List<Artefact> findArtefactsBySearchVerified(@Param("searchVal") String searchVal,
-                                         @Param("curr_date") LocalDateTime current_date);
+                                         @Param("curr_date") LocalDateTime currentDate);
 
     @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and sensitivity = 'PUBLIC' and "
         + "display_from < :curr_date and display_to> :curr_date",
         nativeQuery = true)
     List<Artefact> findArtefactsBySearchUnverified(@Param("searchVal") String searchVal,
-                                                 @Param("curr_date") LocalDateTime current_date);
+                                                 @Param("curr_date") LocalDateTime currentDate);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -2,13 +2,16 @@ package uk.gov.hmcts.reform.pip.data.management.database;
 
 import org.apache.tomcat.jni.Local;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -17,11 +20,16 @@ public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
 
     List<Artefact> findArtefactsByArtefactIdIsNotNull();
 
-    List<Artefact> findArtefactsByDisplayFromBeforeAndDisplayToAfter(LocalDateTime currentDate,
-                                                                     LocalDateTime currentDate1);
 
-    List<Artefact> findArtefactsByDisplayFromBeforeAndDisplayToAfterAndSensitivityEquals(LocalDateTime currentDate,
-                                                                                         LocalDateTime currentDate1,
-                                                                                         Sensitivity sensitivity);
+    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < :curr_date "
+        + "and display_to> :curr_date",
+    nativeQuery = true)
+    List<Artefact> findArtefactsBySearchVerified(@Param("searchVal") String searchVal,
+                                         @Param("curr_date") LocalDateTime current_date);
 
+    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and sensitivity = 'PUBLIC' and "
+        + "display_from < :curr_date and display_to> :curr_date",
+        nativeQuery = true)
+    List<Artefact> findArtefactsBySearchUnverified(@Param("searchVal") String searchVal,
+                                                 @Param("curr_date") LocalDateTime current_date);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -1,13 +1,27 @@
 package uk.gov.hmcts.reform.pip.data.management.database;
 
+import org.apache.tomcat.jni.Local;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
+import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
     Optional<Artefact> findBySourceArtefactIdAndProvenance(String sourceArtefactId, String provenance);
+
+    List<Artefact> findArtefactsByArtefactIdIsNotNull();
+
+    List<Artefact> findArtefactsByDisplayFromBeforeAndDisplayToAfter(LocalDateTime currentDate,
+                                                                     LocalDateTime currentDate1);
+
+    List<Artefact> findArtefactsByDisplayFromBeforeAndDisplayToAfterAndSensitivityEquals(LocalDateTime currentDate,
+                                                                                         LocalDateTime currentDate1,
+                                                                                         Sensitivity sensitivity);
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
@@ -2,10 +2,13 @@ package uk.gov.hmcts.reform.pip.data.management.database;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.sun.xml.bind.api.impl.NameConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Class with handles the interaction with the Azure Blob Service.
@@ -35,6 +38,21 @@ public class AzureBlobService {
         blobClient.upload(new ByteArrayInputStream(payloadBytes), payloadBytes.length, true);
 
         return blobContainerClient.getBlobContainerUrl() + '/' + blobName;
+    }
+
+    public String getBlobData(String sourceArtefactId, String provenance) {
+        String blobName = sourceArtefactId + '-' + provenance;
+        BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        blobClient.downloadStream(stream);
+        return stream.toString();
+    }
+
+    public String getBlobDataFromUrl(String url) {
+        BlobClient blobClient = blobContainerClient.getBlobClient(url);
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        blobClient.downloadStream(stream);
+        return stream.toString();
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
@@ -39,9 +39,6 @@ public class AzureBlobService {
         return blobContainerClient.getBlobContainerUrl() + '/' + blobName;
     }
 
-    protected ByteArrayOutputStream createByteArrayOutputStream() {
-        return new ByteArrayOutputStream();
-    }
 
     /**
      * Gets the data held within a blob from the blob service.
@@ -53,7 +50,7 @@ public class AzureBlobService {
     public String getBlobData(String sourceArtefactId, String provenance) {
         String blobName = sourceArtefactId + '-' + provenance;
         BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
-        ByteArrayOutputStream stream = createByteArrayOutputStream();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
         blobClient.downloadStream(stream);
         return stream.toString();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
@@ -39,6 +39,10 @@ public class AzureBlobService {
         return blobContainerClient.getBlobContainerUrl() + '/' + blobName;
     }
 
+    protected ByteArrayOutputStream createByteArrayOutputStream() {
+        return new ByteArrayOutputStream();
+    }
+
     /**
      * Gets the data held within a blob from the blob service.
      *
@@ -49,7 +53,7 @@ public class AzureBlobService {
     public String getBlobData(String sourceArtefactId, String provenance) {
         String blobName = sourceArtefactId + '-' + provenance;
         BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        ByteArrayOutputStream stream = createByteArrayOutputStream();
         blobClient.downloadStream(stream);
         return stream.toString();
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobService.java
@@ -2,13 +2,11 @@ package uk.gov.hmcts.reform.pip.data.management.database;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
-import com.sun.xml.bind.api.impl.NameConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Class with handles the interaction with the Azure Blob Service.
@@ -25,9 +23,10 @@ public class AzureBlobService {
 
     /**
      * Creates the payload in the Azure blob service.
+     *
      * @param sourceArtefactId The source ID to call the blob.
-     * @param provenance The provenance to call the blob.
-     * @param payload The payload to create
+     * @param provenance       The provenance to call the blob.
+     * @param payload          The payload to create
      * @return The URL to where the payload has been created
      */
     public String createPayload(String sourceArtefactId, String provenance, String payload) {
@@ -40,16 +39,16 @@ public class AzureBlobService {
         return blobContainerClient.getBlobContainerUrl() + '/' + blobName;
     }
 
+    /**
+     * Gets the data held within a blob from the blob service.
+     *
+     * @param sourceArtefactId The provenance with which to retrieve the blob data
+     * @param provenance       The artifact ID with which to retrieve the blob data
+     * @return the data contained within the blob in String format.
+     */
     public String getBlobData(String sourceArtefactId, String provenance) {
         String blobName = sourceArtefactId + '-' + provenance;
         BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        blobClient.downloadStream(stream);
-        return stream.toString();
-    }
-
-    public String getBlobDataFromUrl(String url) {
-        BlobClient blobClient = blobContainerClient.getBlobClient(url);
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         blobClient.downloadStream(stream);
         return stream.toString();

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ public class GlobalExceptionHandler {
     /**
      * Template exception handler, that handles a custom DataStorageNotFoundException,
      * and returns a 404 in the standard format.
+     *
      * @param ex The exception that has been thrown.
      * @return The error response, modelled using the ExceptionResponse object.
      */
@@ -77,12 +78,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BlobStorageException.class)
-        public ResponseEntity<ExceptionResponse> handle(BlobStorageException ex) {
+    public ResponseEntity<ExceptionResponse> handle(BlobStorageException ex) {
         ExceptionResponse exceptionResponse = new ExceptionResponse();
-        if(Objects.equals(ex.getErrorCode().toString(), "BlobNotFound")) {
+        if (Objects.equals(ex.getErrorCode().toString(), "BlobNotFound")) {
             exceptionResponse.setMessage("404: Unable to find a blob matching the given inputs");
-        }
-        else{
+        } else {
             exceptionResponse.setMessage(ex.getErrorCode().toString());
         }
         exceptionResponse.setTimestamp(LocalDateTime.now());

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.pip.data.management.errorhandling;
 
-import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +13,6 @@ import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFound
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -82,15 +80,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BlobStorageException.class)
     public ResponseEntity<ExceptionResponse> handle(BlobStorageException ex) {
         ExceptionResponse exceptionResponse = new ExceptionResponse();
-        if (Objects.equals(ex.getErrorCode(), BlobErrorCode.BLOB_NOT_FOUND)) {
-            exceptionResponse.setMessage("Unable to find a blob matching the given inputs");
-            exceptionResponse.setTimestamp(LocalDateTime.now());
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
-        } else {
-            exceptionResponse.setMessage(ex.getErrorCode().toString());
-            exceptionResponse.setTimestamp(LocalDateTime.now());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
-        }
+        exceptionResponse.setMessage(ex.getMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
     }
 
     @ExceptionHandler(UnauthorisedRequestException.class)
@@ -100,6 +92,5 @@ public class GlobalExceptionHandler {
         exceptionResponse.setTimestamp(LocalDateTime.now());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exceptionResponse);
     }
- 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pip.data.management.errorhandling;
 
+import com.azure.storage.blob.models.BlobStorageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -11,6 +12,7 @@ import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.EmptyReq
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -73,5 +75,19 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
     }
+
+    @ExceptionHandler(BlobStorageException.class)
+        public ResponseEntity<ExceptionResponse> handle(BlobStorageException ex) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        if(Objects.equals(ex.getErrorCode().toString(), "BlobNotFound")) {
+            exceptionResponse.setMessage("404: Unable to find a blob matching the given inputs");
+        }
+        else{
+            exceptionResponse.setMessage(ex.getErrorCode().toString());
+        }
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+    }
+
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pip.data.management.errorhandling;
 
+import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -80,8 +81,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BlobStorageException.class)
     public ResponseEntity<ExceptionResponse> handle(BlobStorageException ex) {
         ExceptionResponse exceptionResponse = new ExceptionResponse();
-        if (Objects.equals(ex.getErrorCode().toString(), "BlobNotFound")) {
-            exceptionResponse.setMessage("404: Unable to find a blob matching the given inputs");
+        if (Objects.equals(ex.getErrorCode(), BlobErrorCode.BLOB_NOT_FOUND)) {
+            exceptionResponse.setMessage("Unable to find a blob matching the given inputs");
             exceptionResponse.setTimestamp(LocalDateTime.now());
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.DataStorageNotFoundException;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.EmptyRequestHeaderException;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -92,5 +93,13 @@ public class GlobalExceptionHandler {
         }
     }
 
+    @ExceptionHandler(UnauthorisedRequestException.class)
+    public ResponseEntity<ExceptionResponse> handle(UnauthorisedRequestException ex) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse();
+        exceptionResponse.setMessage(ex.getMessage());
+        exceptionResponse.setTimestamp(LocalDateTime.now());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exceptionResponse);
+    }
+ 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandler.java
@@ -82,11 +82,13 @@ public class GlobalExceptionHandler {
         ExceptionResponse exceptionResponse = new ExceptionResponse();
         if (Objects.equals(ex.getErrorCode().toString(), "BlobNotFound")) {
             exceptionResponse.setMessage("404: Unable to find a blob matching the given inputs");
+            exceptionResponse.setTimestamp(LocalDateTime.now());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
         } else {
             exceptionResponse.setMessage(ex.getErrorCode().toString());
+            exceptionResponse.setTimestamp(LocalDateTime.now());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
         }
-        exceptionResponse.setTimestamp(LocalDateTime.now());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/exceptions/UnauthorisedRequestException.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/exceptions/UnauthorisedRequestException.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions;
+
+/**
+ * Exception that captures the message when an unauthorised request is made to the database.
+ */
+public class UnauthorisedRequestException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor for the Exception.
+     *
+     * @param message The message to return to the end user
+     */
+    public UnauthorisedRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/models/publication/Sensitivity.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/models/publication/Sensitivity.java
@@ -4,5 +4,5 @@ package uk.gov.hmcts.reform.pip.data.management.models.publication;
  * A class which defines the sensitivity of the publication.
  */
 public enum Sensitivity {
-    PUBLIC, STANDARD, WARNED
+    PUBLIC, CLASSIFIED, INTERNAL, PRIVATE
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -103,7 +103,7 @@ public class PublicationService {
             String provenance = artefact.getProvenance();
             return azureBlobService.getBlobData(sourceArtefactId, provenance);
         } else {
-            throw new NotFoundException("No artefact found by that name.");
+            throw new NotFoundException(String.format("No artefact found with the ID: %s", artefactId));
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -80,7 +80,7 @@ public class PublicationService {
     }
 
     /**
-     * takes in provenance and artefact id and returns the data within the matching blob in string format.
+     * takes in artefact id and returns the data within the matching blob in string format.
      * @param artefactId represents the artefact id which is then used to get an artefact to populate the inputs
      *                   for the blob request
      * @return the data within the blob in string format

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.pip.data.management.database.AzureBlobService;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
+import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
 import java.time.LocalDateTime;
@@ -89,20 +90,20 @@ public class PublicationService {
      * @return the data within the blob in string format
      */
     public String getByArtefactId(UUID artefactId, Boolean verification) {
-        if (!verification) {
-            throw new UnauthorisedRequestException("Unauthorised Request.");
-        }
+
         Optional<Artefact> optionalArtefact = artefactRepository.findByArtefactId(artefactId);
 
         if (optionalArtefact.isPresent()) {
             Artefact artefact;
             artefact = optionalArtefact.get();
+            if (!verification && artefact.getSensitivity() != Sensitivity.PUBLIC) {
+                throw new UnauthorisedRequestException("Unauthorised Request.");
+            }
             String sourceArtefactId = artefact.getSourceArtefactId();
             String provenance = artefact.getProvenance();
             return azureBlobService.getBlobData(sourceArtefactId, provenance);
         } else {
             throw new NotFoundException("No artefact found by that name.");
         }
-
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -1,17 +1,14 @@
 package uk.gov.hmcts.reform.pip.data.management.service;
 
-import org.apache.tomcat.jni.Local;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pip.data.management.database.ArtefactRepository;
 import uk.gov.hmcts.reform.pip.data.management.database.AzureBlobService;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
-import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -65,25 +62,35 @@ public class PublicationService {
         return artefactRepository.findArtefactsByArtefactIdIsNotNull();
     }
 
+    /**
+     * Get all relevant artefacts relating to a given court ID.
+     *
+     * @param searchValue - represents the court ID in question being searched for
+     * @param verified    - represents the verification status of the user. Currently only verified/non-verified, but
+     *                    will include other verified user types in the future
+     * @return a list of all artefacts that fulfil the timing criteria, match the given court id and sensitivity
+     *                    associated with given verification status
+     */
     public List<Artefact> findAllWithSearch(String searchValue, Boolean verified) {
         LocalDateTime currDate = LocalDateTime.now();
-        if(verified){
+        if (verified) {
             return artefactRepository.findArtefactsBySearchVerified(searchValue, currDate);
-        }
-        else{
+        } else {
             return artefactRepository.findArtefactsBySearchUnverified(searchValue, currDate);
         }
 
     }
 
+    /**
+     * takes in provenance and artefact id and returns the data within the matching blob in string format.
+     *
+     * @param provenance represents the provenance component of the blob
+     * @param artefactId represents the artefact id component of the blob
+     * @return the data within the blob in string format
+     */
     public String getFromBlobStorage(String provenance, String artefactId) {
         return azureBlobService.getBlobData(artefactId, provenance);
     }
-
-    public String getFromBlobStorageUrl(String url) {
-        return azureBlobService.getBlobDataFromUrl(url);
-    }
-
 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pip.data.management.database.ArtefactRepository;
 import uk.gov.hmcts.reform.pip.data.management.database.AzureBlobService;
+import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
@@ -81,6 +82,7 @@ public class PublicationService {
 
     /**
      * takes in artefact id and returns the data within the matching blob in string format.
+     *
      * @param artefactId represents the artefact id which is then used to get an artefact to populate the inputs
      *                   for the blob request
      * @return the data within the blob in string format
@@ -94,7 +96,7 @@ public class PublicationService {
             String provenance = artefact.getProvenance();
             return azureBlobService.getBlobData(sourceArtefactId, provenance);
         } else {
-            return azureBlobService.getBlobData("", "");
+            throw new NotFoundException("No artefact found by that name.");
         }
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -94,7 +94,7 @@ public class PublicationService {
             String provenance = artefact.getProvenance();
             return azureBlobService.getBlobData(sourceArtefactId, provenance);
         } else {
-            return null;
+            return azureBlobService.getBlobData("", "");
         }
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * This class contains the business logic for handling of Publications.
@@ -36,7 +37,7 @@ public class PublicationService {
      * Method that handles the creation or updating of a new publication.
      *
      * @param artefact The artifact that needs to be created.
-     * @param payload  The paylaod for the artefact that needs to be created.
+     * @param payload  The payload for the artefact that needs to be created.
      * @return Returns the UUID of the artefact that was created.
      */
     public Artefact createPublication(Artefact artefact, String payload) {
@@ -68,7 +69,7 @@ public class PublicationService {
      * @return a list of all artefacts that fulfil the timing criteria, match the given court id and sensitivity
      *                    associated with given verification status
      */
-    public List<Artefact> findAllWithSearch(String searchValue, Boolean verified) {
+    public List<Artefact> findAllByCourtId(String searchValue, Boolean verified) {
         LocalDateTime currDate = LocalDateTime.now();
         if (verified) {
             return artefactRepository.findArtefactsBySearchVerified(searchValue, currDate);
@@ -80,14 +81,21 @@ public class PublicationService {
 
     /**
      * takes in provenance and artefact id and returns the data within the matching blob in string format.
-     *
-     * @param provenance represents the provenance component of the blob
-     * @param artefactId represents the artefact id component of the blob
+     * @param artefactId represents the artefact id which is then used to get an artefact to populate the inputs
+     *                   for the blob request
      * @return the data within the blob in string format
      */
-    public String getFromBlobStorage(String provenance, String artefactId) {
-        return azureBlobService.getBlobData(artefactId, provenance);
+    public String getByArtefactId(UUID artefactId) {
+        Optional<Artefact> optionalArtefact = artefactRepository.findByArtefactId(artefactId);
+        if (optionalArtefact.isPresent()) {
+            Artefact artefact;
+            artefact = optionalArtefact.get();
+            String sourceArtefactId = artefact.getSourceArtefactId();
+            String provenance = artefact.getProvenance();
+            return azureBlobService.getBlobData(sourceArtefactId, provenance);
+        } else {
+            return null;
+        }
+
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -64,28 +65,25 @@ public class PublicationService {
         return artefactRepository.findArtefactsByArtefactIdIsNotNull();
     }
 
-    public List<Artefact> findAllArtefactsInDateRange() {
-        LocalDateTime currentTime = LocalDateTime.now();
-        LocalDateTime currentTime2 = LocalDateTime.now();
-        return artefactRepository.findArtefactsByDisplayFromBeforeAndDisplayToAfter(currentTime, currentTime2);
-    }
-
-    public List<Artefact> findAllArtefactsInDateRangeAndPublic() {
-        LocalDateTime currentTime = LocalDateTime.now();
-        return artefactRepository
-            .findArtefactsByDisplayFromBeforeAndDisplayToAfterAndSensitivityEquals(
-                currentTime,
-                currentTime,
-                Sensitivity.PUBLIC
-            );
-    }
-
-    public List<Artefact> findAllRelevantArtefacts(Boolean verified, String searchValue) {
-        if (verified) {
-            return findAllArtefactsInDateRange();
-        } else {
-            return findAllArtefactsInDateRangeAndPublic();
+    public List<Artefact> findAllWithSearch(String searchValue, Boolean verified) {
+        LocalDateTime currDate = LocalDateTime.now();
+        if(verified){
+            return artefactRepository.findArtefactsBySearchVerified(searchValue, currDate);
         }
+        else{
+            return artefactRepository.findArtefactsBySearchUnverified(searchValue, currDate);
+        }
+
     }
+
+    public String getFromBlobStorage(String provenance, String artefactId) {
+        return azureBlobService.getBlobData(artefactId, provenance);
+    }
+
+    public String getFromBlobStorageUrl(String url) {
+        return azureBlobService.getBlobDataFromUrl(url);
+    }
+
+
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -58,9 +58,6 @@ public class PublicationService {
         return artefactRepository.save(artefact);
     }
 
-    public List<Artefact> findAllArtefacts() {
-        return artefactRepository.findArtefactsByArtefactIdIsNotNull();
-    }
 
     /**
      * Get all relevant artefacts relating to a given court ID.

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pip.data.management.database.ArtefactRepository;
 import uk.gov.hmcts.reform.pip.data.management.database.AzureBlobService;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
@@ -87,8 +88,12 @@ public class PublicationService {
      *                   for the blob request
      * @return the data within the blob in string format
      */
-    public String getByArtefactId(UUID artefactId) {
+    public String getByArtefactId(UUID artefactId, Boolean verification) {
+        if (!verification) {
+            throw new UnauthorisedRequestException("Unauthorised Request.");
+        }
         Optional<Artefact> optionalArtefact = artefactRepository.findByArtefactId(artefactId);
+
         if (optionalArtefact.isPresent()) {
             Artefact artefact;
             artefact = optionalArtefact.get();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,6 +23,7 @@ spring:
     name: PIP Data Management
   datasource:
     driver-class-name: org.postgresql.Driver
+
     url: jdbc:postgresql://${DB_NAME}.postgres.database.azure.com:${DB_PORT}/postgres
     username: ${DB_USER}
     password: ${DB_PASS}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ spring:
       # this ensures the db persists after spring boot connection drops.
       ddl-auto: update
 
+
 azure:
   application-insights:
     instrumentation-key: ${rpe.AppInsightsInstrumentationKey:00000000-0000-0000-0000-000000000000}
@@ -62,5 +63,3 @@ payload:
       case-urn: "$['CourtList']['CourtList'][*]['courtroom']['sittings'][*]['Hearing']['Case']['CaseURN']"
       court-name: "$['CourtList']['CourtList'][*]['CourtHouse']['CourtHouseName']"
       court-id: "$['CourtList']['CourtList'][*]['CourtHouse']['CourtHouseCode']"
-
-

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -131,7 +131,7 @@ class PublicationControllerTest {
 
     @Test
     void testBlobEndpointReturnsOk() {
-        assertEquals(HttpStatus.OK, publicationController.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE)
+        assertEquals(HttpStatus.OK, publicationController.getBlobData(ARTEFACT_ID)
             .getStatusCode(), STATUS_CODE_MATCH);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.pip.data.management.helpers.TestConstants.STATUS_CODE_MATCH;
 
 @ExtendWith(MockitoExtension.class)
 class PublicationControllerTest {
@@ -126,5 +127,23 @@ class PublicationControllerTest {
         assertEquals("x-provenance is mandatory however an empty value is provided",
                      emptyRequestHeaderException.getMessage(),
                      VALIDATION_EXPECTED_MESSAGE);
+    }
+
+    @Test
+    void testBlobEndpointReturnsOk() {
+        assertEquals(HttpStatus.OK, publicationController.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE)
+            .getStatusCode(), STATUS_CODE_MATCH);
+    }
+
+    @Test
+    void testSearchEndpointReturnsOkWithTrue() {
+        assertEquals(HttpStatus.OK, publicationController.getAllRelevantArtefacts(EMPTY_FIELD, true)
+            .getStatusCode(), STATUS_CODE_MATCH);
+    }
+
+    @Test
+    void testSearchEndpointReturnsOkWithFalse() {
+        assertEquals(HttpStatus.OK, publicationController.getAllRelevantArtefacts(EMPTY_FIELD, false)
+            .getStatusCode(), STATUS_CODE_MATCH);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -173,7 +173,6 @@ class PublicationControllerTest {
                      STATUS_CODE_MATCH
         );
         assertEquals(artefactWithId.toString(), unmappedBlob.getBody(), VALIDATION_EXPECTED_MESSAGE);
-
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -8,7 +8,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.EmptyRequestHeaderException;
-import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.ArtefactType;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Language;

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.EmptyRequestHeaderException;
+import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.ArtefactType;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Language;
@@ -197,4 +198,5 @@ class PublicationControllerTest {
         assertEquals(unmappedArtefact.getBody(), artefactList, VALIDATION_EXPECTED_MESSAGE);
         assertEquals(unmappedArtefact.getStatusCode(), HttpStatus.OK, STATUS_CODE_MATCH);
     }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -138,7 +138,7 @@ class PublicationControllerTest {
 
     @Test
     void testBlobEndpointReturnsOk() {
-        assertEquals(HttpStatus.OK, publicationController.getBlobData(ARTEFACT_ID)
+        assertEquals(HttpStatus.OK, publicationController.getBlobData(ARTEFACT_ID, true)
             .getStatusCode(), STATUS_CODE_MATCH);
     }
 
@@ -167,8 +167,8 @@ class PublicationControllerTest {
             .type(ARTEFACT_TYPE)
             .payload(PAYLOAD_URL)
             .build();
-        when(publicationService.getByArtefactId(any())).thenReturn(String.valueOf(artefactWithId));
-        ResponseEntity<String> unmappedBlob = publicationController.getBlobData(UUID.randomUUID());
+        when(publicationService.getByArtefactId(any(), any())).thenReturn(String.valueOf(artefactWithId));
+        ResponseEntity<String> unmappedBlob = publicationController.getBlobData(UUID.randomUUID(), true);
         assertEquals(HttpStatus.OK, unmappedBlob.getStatusCode(),
                      STATUS_CODE_MATCH
         );

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationControllerTest.java
@@ -15,10 +15,12 @@ import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 import uk.gov.hmcts.reform.pip.data.management.service.PublicationService;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -44,7 +46,6 @@ class PublicationControllerTest {
     private static final String PAYLOAD = "payload";
     private static final String PAYLOAD_URL = "This is a test payload";
     private static final String EMPTY_FIELD = "";
-
     private static final String VALIDATION_EXPECTED_MESSAGE =
         "The expected exception does not contain the correct message";
 
@@ -94,9 +95,11 @@ class PublicationControllerTest {
                 );
             });
 
-        assertEquals("x-provenance is mandatory however an empty value is provided",
-                     emptyRequestHeaderException.getMessage(),
-                     VALIDATION_EXPECTED_MESSAGE);
+        assertEquals(
+            "x-provenance is mandatory however an empty value is provided",
+            emptyRequestHeaderException.getMessage(),
+            VALIDATION_EXPECTED_MESSAGE
+        );
     }
 
     @Test
@@ -109,9 +112,11 @@ class PublicationControllerTest {
                 );
             });
 
-        assertEquals("x-source-artefact-id is mandatory however an empty value is provided",
-                     emptyRequestHeaderException.getMessage(),
-                     VALIDATION_EXPECTED_MESSAGE);
+        assertEquals(
+            "x-source-artefact-id is mandatory however an empty value is provided",
+            emptyRequestHeaderException.getMessage(),
+            VALIDATION_EXPECTED_MESSAGE
+        );
     }
 
     @Test
@@ -124,9 +129,11 @@ class PublicationControllerTest {
                 );
             });
 
-        assertEquals("x-provenance is mandatory however an empty value is provided",
-                     emptyRequestHeaderException.getMessage(),
-                     VALIDATION_EXPECTED_MESSAGE);
+        assertEquals(
+            "x-provenance is mandatory however an empty value is provided",
+            emptyRequestHeaderException.getMessage(),
+            VALIDATION_EXPECTED_MESSAGE
+        );
     }
 
     @Test
@@ -137,13 +144,57 @@ class PublicationControllerTest {
 
     @Test
     void testSearchEndpointReturnsOkWithTrue() {
-        assertEquals(HttpStatus.OK, publicationController.getAllRelevantArtefacts(EMPTY_FIELD, true)
+        assertEquals(HttpStatus.OK, publicationController.getAllRelevantArtefactsByCourtId(EMPTY_FIELD, true)
             .getStatusCode(), STATUS_CODE_MATCH);
     }
 
     @Test
     void testSearchEndpointReturnsOkWithFalse() {
-        assertEquals(HttpStatus.OK, publicationController.getAllRelevantArtefacts(EMPTY_FIELD, false)
+        assertEquals(HttpStatus.OK, publicationController.getAllRelevantArtefactsByCourtId(EMPTY_FIELD, false)
             .getStatusCode(), STATUS_CODE_MATCH);
+    }
+
+    @Test
+    void checkBodyBlobs() {
+        Artefact artefactWithId = Artefact.builder()
+            .artefactId(ARTEFACT_ID)
+            .sourceArtefactId(SOURCE_ARTEFACT_ID)
+            .displayFrom(DISPLAY_FROM)
+            .displayTo(DISPLAY_TO)
+            .language(LANGUAGE)
+            .provenance(PROVENANCE)
+            .sensitivity(SENSITIVITY)
+            .type(ARTEFACT_TYPE)
+            .payload(PAYLOAD_URL)
+            .build();
+        when(publicationService.getByArtefactId(any())).thenReturn(String.valueOf(artefactWithId));
+        ResponseEntity<String> unmappedBlob = publicationController.getBlobData(UUID.randomUUID());
+        assertEquals(HttpStatus.OK, unmappedBlob.getStatusCode(),
+                     STATUS_CODE_MATCH
+        );
+        assertEquals(artefactWithId.toString(), unmappedBlob.getBody(), VALIDATION_EXPECTED_MESSAGE);
+
+    }
+
+    @Test
+    void checkBodyArtefacts() {
+        Artefact artefactWithId = Artefact.builder()
+            .artefactId(ARTEFACT_ID)
+            .sourceArtefactId(SOURCE_ARTEFACT_ID)
+            .displayFrom(DISPLAY_FROM)
+            .displayTo(DISPLAY_TO)
+            .language(LANGUAGE)
+            .provenance(PROVENANCE)
+            .sensitivity(SENSITIVITY)
+            .type(ARTEFACT_TYPE)
+            .payload(PAYLOAD_URL)
+            .build();
+        List<Artefact> artefactList = List.of(artefactWithId);
+
+        when(publicationService.findAllByCourtId(any(), any())).thenReturn(artefactList);
+        ResponseEntity<List<Artefact>> unmappedArtefact = publicationController
+            .getAllRelevantArtefactsByCourtId(EMPTY_FIELD, true);
+        assertEquals(unmappedArtefact.getBody(), artefactList, VALIDATION_EXPECTED_MESSAGE);
+        assertEquals(unmappedArtefact.getStatusCode(), HttpStatus.OK, STATUS_CODE_MATCH);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
@@ -4,11 +4,21 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,4 +50,31 @@ class AzureBlobServiceTest {
         assertEquals(CONTAINER_URL + "/" + blobName, blobUrl, "Payload URL does not"
             + "contain the correct value");
     }
+
+
+    @Test
+    void testGetBlobData() {
+        String blobName = SOURCE_ARTEFACT_ID + '-' + PROVENANCE;
+        when(blobContainerClient.getBlobClient(blobName)).thenReturn(blobClient);
+        assertEquals(blobClient, blobContainerClient.getBlobClient(blobName), "Wrong blobclient loaded");
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        String s = "test data here";
+        for (int i = 0; i < s.length(); i++) {
+            stream.write(s.charAt(i));
+        }
+        ArgumentCaptor<ByteArrayOutputStream> captor = ArgumentCaptor.forClass(ByteArrayOutputStream.class);
+        doNothing().when(blobClient).downloadStream(captor.capture());
+        blobClient.downloadStream(stream);
+        assertEquals(s, captor.getValue().toString(),
+                     "stream writing incorrectly"
+        );
+    }
+
+    // I want to understand how exactly to manipulate the internal "stream" ByteArrayOutputStream within the
+    // getBlobData method. I have looked at several different methods:
+    // 1) doAnswer() - this seems to be potentially fruitful but I'm struggling to work out how it could affect the
+    // internals.
+    // 2) using a spy() within mockito and putting the stream into a protected class so i can watch the value of the
+    // stream variable. This seems like another potentially good option, but i basically just need clarification.
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
@@ -4,21 +4,15 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.UUID;
-
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,30 +45,15 @@ class AzureBlobServiceTest {
             + "contain the correct value");
     }
 
-
     @Test
     void testGetBlobData() {
         String blobName = SOURCE_ARTEFACT_ID + '-' + PROVENANCE;
         when(blobContainerClient.getBlobClient(blobName)).thenReturn(blobClient);
-        assertEquals(blobClient, blobContainerClient.getBlobClient(blobName), "Wrong blobclient loaded");
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        String s = "test data here";
-        for (int i = 0; i < s.length(); i++) {
-            stream.write(s.charAt(i));
-        }
-        ArgumentCaptor<ByteArrayOutputStream> captor = ArgumentCaptor.forClass(ByteArrayOutputStream.class);
-        doNothing().when(blobClient).downloadStream(captor.capture());
-        blobClient.downloadStream(stream);
-        assertEquals(s, captor.getValue().toString(),
-                     "stream writing incorrectly"
-        );
+        doNothing().when(blobClient).downloadStream(any());
+        assertThat("Error Message", azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE),
+                   instanceOf(String.class));
+        assertEquals(azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE), "",
+                     "Wrong string detected");
     }
-
-    // I want to understand how exactly to manipulate the internal "stream" ByteArrayOutputStream within the
-    // getBlobData method. I have looked at several different methods:
-    // 1) doAnswer() - this seems to be potentially fruitful but I'm struggling to work out how it could affect the
-    // internals.
-    // 2) using a spy() within mockito and putting the stream into a protected class so i can watch the value of the
-    // stream variable. This seems like another potentially good option, but i basically just need clarification.
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
@@ -55,5 +55,4 @@ class AzureBlobServiceTest {
         assertEquals(azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE), "",
                      "Wrong string detected");
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/database/AzureBlobServiceTest.java
@@ -50,9 +50,13 @@ class AzureBlobServiceTest {
         String blobName = SOURCE_ARTEFACT_ID + '-' + PROVENANCE;
         when(blobContainerClient.getBlobClient(blobName)).thenReturn(blobClient);
         doNothing().when(blobClient).downloadStream(any());
-        assertThat("Error Message", azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE),
-                   instanceOf(String.class));
+        assertThat(
+            "Wrong return type - should be string",
+            azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE),
+            instanceOf(String.class)
+        );
         assertEquals(azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE), "",
-                     "Wrong string detected");
+                     "Wrong string detected"
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
@@ -42,7 +42,7 @@ class GlobalExceptionHandlerTest {
     private static final String BAD_REQUEST_ASSERTION = "Status code should be of type: Not Found";
     private static final String NOT_FOUND_ASSERTION = "Status code should be of type: Bad Request";
     static final String ASSERTION_RESPONSE_BODY = "Response should contain a body";
-    private static final String BLOBSTORAGE_MESSAGE = "404: Unable to find a blob matching the given inputs";
+    private static final String BLOBSTORAGE_MESSAGE = "Unable to find a blob matching the given inputs";
 
     private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.DataStor
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.EmptyRequestHeaderException;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.HearingNotFoundException;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -43,7 +44,7 @@ class GlobalExceptionHandlerTest {
     private static final String NOT_FOUND_ASSERTION = "Status code should be of type: Bad Request";
     static final String ASSERTION_RESPONSE_BODY = "Response should contain a body";
     private static final String BLOBSTORAGE_MESSAGE = "Unable to find a blob matching the given inputs";
-
+    private static final String NOT_NULL_MESSAGE = "Exception body should not be null";
     private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
 
     @BeforeAll
@@ -186,11 +187,25 @@ class GlobalExceptionHandlerTest {
             globalExceptionHandler.handle(blobStorageException);
 
         assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode(), BAD_REQUEST_ASSERTION);
-        assertNotNull(responseEntity.getBody(), "Exception body should not be null");
+        assertNotNull(responseEntity.getBody(), NOT_NULL_MESSAGE);
         assertTrue(
             responseEntity.getBody().getMessage().contains(
                 "InvalidOperation"),
             "The exception response should contain the name of the field"
         );
+    }
+
+    @Test
+    void testUnauthorisedRequestException() {
+        UnauthorisedRequestException unauthorisedRequestException = new UnauthorisedRequestException(TEST_MESSAGE);
+        ResponseEntity<ExceptionResponse> responseEntity =
+            globalExceptionHandler.handle(unauthorisedRequestException);
+        assertEquals(HttpStatus.UNAUTHORIZED, responseEntity.getStatusCode(),
+                     "Should be unauthorised exception");
+        assertNotNull(responseEntity.getBody(), NOT_NULL_MESSAGE);
+        assertTrue(responseEntity.getBody().getMessage().contains(TEST_MESSAGE),
+                   "Exception body doesn't match test message");
+
+
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.pip.data.management.errorhandling;
 
-import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -43,7 +42,6 @@ class GlobalExceptionHandlerTest {
     private static final String BAD_REQUEST_ASSERTION = "Status code should be of type: Not Found";
     private static final String NOT_FOUND_ASSERTION = "Status code should be of type: Bad Request";
     static final String ASSERTION_RESPONSE_BODY = "Response should contain a body";
-    private static final String BLOBSTORAGE_MESSAGE = "Unable to find a blob matching the given inputs";
     private static final String NOT_NULL_MESSAGE = "Exception body should not be null";
     private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
 
@@ -164,35 +162,19 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void testBlobStorageException404() {
-        when(blobStorageException.getErrorCode()).thenReturn(BlobErrorCode.BLOB_NOT_FOUND);
+    void testBlobStorageException() {
+        when(blobStorageException.getMessage()).thenReturn(TEST_MESSAGE);
 
         ResponseEntity<ExceptionResponse> responseEntity =
             globalExceptionHandler.handle(blobStorageException);
 
         assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode(), BAD_REQUEST_ASSERTION);
-        assertNotNull(responseEntity.getBody(),ASSERTION_RESPONSE_BODY);
+        assertNotNull(responseEntity.getBody(), ASSERTION_RESPONSE_BODY);
         assertTrue(
-            responseEntity.getBody().getMessage().contains(
-                BLOBSTORAGE_MESSAGE),
-                "The exception response should contain the name of the field"
+            responseEntity.getBody().getMessage().contains(TEST_MESSAGE),
+            "Exception body doesn't match test message"
         );
-    }
 
-    @Test
-    void testBlobStorageExceptionOtherType() {
-        when(blobStorageException.getErrorCode()).thenReturn(BlobErrorCode.INVALID_OPERATION);
-
-        ResponseEntity<ExceptionResponse> responseEntity =
-            globalExceptionHandler.handle(blobStorageException);
-
-        assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode(), BAD_REQUEST_ASSERTION);
-        assertNotNull(responseEntity.getBody(), NOT_NULL_MESSAGE);
-        assertTrue(
-            responseEntity.getBody().getMessage().contains(
-                "InvalidOperation"),
-            "The exception response should contain the name of the field"
-        );
     }
 
     @Test
@@ -201,10 +183,13 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ExceptionResponse> responseEntity =
             globalExceptionHandler.handle(unauthorisedRequestException);
         assertEquals(HttpStatus.UNAUTHORIZED, responseEntity.getStatusCode(),
-                     "Should be unauthorised exception");
+                     "Should be unauthorised exception"
+        );
         assertNotNull(responseEntity.getBody(), NOT_NULL_MESSAGE);
-        assertTrue(responseEntity.getBody().getMessage().contains(TEST_MESSAGE),
-                   "Exception body doesn't match test message");
+        assertTrue(
+            responseEntity.getBody().getMessage().contains(TEST_MESSAGE),
+            "Exception body doesn't match test message"
+        );
 
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
@@ -139,6 +139,7 @@ class GlobalExceptionHandlerTest {
         assertTrue(
             responseEntity.getBody().getMessage().contains(
                 String.format("Unable to parse %s. Please check that the value is of the correct format for the field "
+
                                   + "(See Swagger documentation for correct formats)", TEST_NAME)),
             "The exception response should contain the name of the field"
         );
@@ -168,7 +169,7 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ExceptionResponse> responseEntity =
             globalExceptionHandler.handle(blobStorageException);
 
-        assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode(), BAD_REQUEST_ASSERTION);
+        assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode(), BAD_REQUEST_ASSERTION);
         assertNotNull(responseEntity.getBody(),ASSERTION_RESPONSE_BODY);
         assertTrue(
             responseEntity.getBody().getMessage().contains(

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/errorhandling/GlobalExceptionHandlerTest.java
@@ -19,8 +19,6 @@ import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.EmptyReq
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.HearingNotFoundException;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.NotFoundException;
 
-import java.net.http.HttpResponse;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -133,7 +133,7 @@ class PublicationServiceTest {
         when(artefactRepository.findByArtefactId(any())).thenReturn(Optional.of(artefact));
         when(azureBlobService.getBlobData(any(), any()))
             .thenReturn(String.valueOf(artefact));
-        assertEquals(artefact.toString(), publicationService.getByArtefactId(ARTEFACT_ID),
+        assertEquals(artefact.toString(), publicationService.getByArtefactId(ARTEFACT_ID, true),
                      "Artefacts do not match");
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.pip.data.management.database.AzureBlobService;
 import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Language;
+import uk.gov.hmcts.reform.pip.data.management.models.publication.Sensitivity;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
 import java.util.ArrayList;
@@ -173,6 +174,14 @@ class PublicationServiceTest {
 
     @Test
     void checkForUnauthorised() {
+        Artefact artefact = Artefact.builder()
+            .sourceArtefactId(SOURCE_ARTEFACT_ID)
+            .provenance(PROVENANCE)
+            .language(Language.ENGLISH)
+            .sensitivity(Sensitivity.CLASSIFIED)
+            .build();
+
+        when(artefactRepository.findByArtefactId(any())).thenReturn(Optional.of(artefact));
         assertThrows(UnauthorisedRequestException.class, () -> {
             publicationService.getByArtefactId(UUID.randomUUID(), false);
         }, "Should throw an unauthorised request exception.");

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -130,9 +130,9 @@ class PublicationServiceTest {
             .provenance(PROVENANCE)
             .language(Language.ENGLISH)
             .build();
-        when(azureBlobService.getBlobData(SOURCE_ARTEFACT_ID, PROVENANCE))
+        when(azureBlobService.getBlobData(any(), any()))
             .thenReturn(String.valueOf(artefact));
-        assertEquals(artefact.toString(), publicationService.getFromBlobStorage(PROVENANCE, SOURCE_ARTEFACT_ID),
+        assertEquals(artefact.toString(), publicationService.getByArtefactId(ARTEFACT_ID),
                      "Artefacts do not match");
     }
 
@@ -159,9 +159,9 @@ class PublicationServiceTest {
         when(artefactRepository.findArtefactsBySearchVerified(any(), any()))
             .thenReturn(artefactList);
 
-        assertEquals(artefactList, publicationService.findAllWithSearch("abc", true),
+        assertEquals(artefactList, publicationService.findAllByCourtId("abc", true),
                      "Message");
-        assertEquals(artefactList, publicationService.findAllWithSearch("abc", false),
+        assertEquals(artefactList, publicationService.findAllByCourtId("abc", false),
                      "Message");
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -136,7 +136,8 @@ class PublicationServiceTest {
         when(azureBlobService.getBlobData(any(), any()))
             .thenReturn(String.valueOf(artefact));
         assertEquals(artefact.toString(), publicationService.getByArtefactId(ARTEFACT_ID, true),
-                     "Artefacts do not match");
+                     "Artefacts do not match"
+        );
     }
 
     @Test
@@ -163,17 +164,18 @@ class PublicationServiceTest {
             .thenReturn(artefactList);
 
         assertEquals(artefactList, publicationService.findAllByCourtId("abc", true),
-                     "Message");
+                     "Message"
+        );
         assertEquals(artefactList, publicationService.findAllByCourtId("abc", false),
-                     "Message");
+                     "Message"
+        );
     }
 
     @Test
     void checkForUnauthorised() {
-        UnauthorisedRequestException unauthorisedRequestException =
-            assertThrows(UnauthorisedRequestException.class, () -> {
-                publicationService.getByArtefactId(UUID.randomUUID(), false);
-            }, "Should throw an unauthorised request exception.");
+        assertThrows(UnauthorisedRequestException.class, () -> {
+            publicationService.getByArtefactId(UUID.randomUUID(), false);
+        }, "Should throw an unauthorised request exception.");
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -130,6 +130,7 @@ class PublicationServiceTest {
             .provenance(PROVENANCE)
             .language(Language.ENGLISH)
             .build();
+        when(artefactRepository.findByArtefactId(any())).thenReturn(Optional.of(artefact));
         when(azureBlobService.getBlobData(any(), any()))
             .thenReturn(String.valueOf(artefact));
         assertEquals(artefact.toString(), publicationService.getByArtefactId(ARTEFACT_ID),

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.pip.data.management.database.ArtefactRepository;
 import uk.gov.hmcts.reform.pip.data.management.database.AzureBlobService;
+import uk.gov.hmcts.reform.pip.data.management.errorhandling.exceptions.UnauthorisedRequestException;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Language;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
@@ -20,6 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -166,5 +168,14 @@ class PublicationServiceTest {
                      "Message");
     }
 
-
+    @Test
+    void checkForUnauthorised() {
+        UnauthorisedRequestException unauthorisedRequestException =
+            assertThrows(UnauthorisedRequestException.class, () -> {
+                publicationService.getByArtefactId(UUID.randomUUID(), false);
+            }, "Should throw an unauthorised request exception.");
+    }
 }
+
+
+

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.pip.data.management.models.publication.Artefact;
 import uk.gov.hmcts.reform.pip.data.management.models.publication.Language;
 import uk.gov.hmcts.reform.pip.data.management.utils.PayloadExtractor;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -160,8 +159,10 @@ class PublicationServiceTest {
         when(artefactRepository.findArtefactsBySearchVerified(any(), any()))
             .thenReturn(artefactList);
 
-        assertEquals(artefactList, publicationService.findAllWithSearch("abc", true));
-        assertEquals(artefactList, publicationService.findAllWithSearch("abc", false));
+        assertEquals(artefactList, publicationService.findAllWithSearch("abc", true),
+                     "Message");
+        assertEquals(artefactList, publicationService.findAllWithSearch("abc", false),
+                     "Message");
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-945

### Change description ###
Added two new GET endpoints:

####  '/search' #### 
This retrieves from Postgres all data fulfilling the following criteria:
-  A court id exists within the "search" criteria (populated via json path)
-  The display-from value is before the current date time and display-to date after.
-  If the "verified" boolean is true, then the search will return all sensitivity types. 
- If false, then it will only return "public" sensitivity data.

#### '/blob' ####
-  this retrieves the data within a blob as a String from the azure blob storage based on a given URI (which is made up of a combination of the provenance and sourceArtefactID fields.

### Integration test issues: ###
Due to the use of Postgres in real-world usage and H2 in-memory db for integration tests, this PR cannot be currently integration tested (Postgres-specific syntax is used which cannot be emulated by h2). This will be amended in a future ticket, where we will aim to bring in local Postgres for testing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
