### PR TITLE
PUB-985 - Return PDFs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
@@ -880,7 +880,7 @@ class PublicationTest {
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder1 = MockMvcRequestBuilders
 
-            .get(SEARCH_URL + "/12345")
+            .get(SEARCH_URL + "/123")
             .header("verification", "true");
         MvcResult getResponse =
             mockMvc.perform(mockHttpServletRequestBuilder1).andExpect(status().isOk()).andReturn();
@@ -915,7 +915,7 @@ class PublicationTest {
         mockMvc.perform(mockHttpServletRequestBuilder).andExpect(status().isCreated()).andReturn();
 
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder1 = MockMvcRequestBuilders
-            .get(SEARCH_URL + "/12345")
+            .get(SEARCH_URL + "/123")
             .header("verification", "true");
         MvcResult getResponse =
             mockMvc.perform(mockHttpServletRequestBuilder1).andExpect(status().isOk()).andReturn();

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/database/ArtefactRepository.java
@@ -17,15 +17,15 @@ public interface ArtefactRepository extends JpaRepository<Artefact, Long> {
 
     Optional<Artefact> findByArtefactId(UUID artefactId);
 
-    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and display_from < "
+    @Query(value = "select * from Artefact where court_id = :searchVal and display_from < :curr_date and (display_to> "
+        + ":curr_date or display_to is null)",
+        nativeQuery = true)
+    List<Artefact> findArtefactsByCourtIdVerified(@Param("searchVal") String searchVal,
+                                          @Param("curr_date") LocalDateTime currentDate);
+
+    @Query(value = "select * from Artefact where court_id = :searchVal and sensitivity = 'PUBLIC' and display_from < "
         + ":curr_date and (display_to> :curr_date or display_to is null)",
         nativeQuery = true)
-    List<Artefact> findArtefactsBySearchVerified(@Param("searchVal") String searchVal,
-                                         @Param("curr_date") LocalDateTime currentDate);
-
-    @Query(value = "select * from Artefact where search->'court-id'->>0 = :searchVal and sensitivity = 'PUBLIC' "
-        + "and display_from < :curr_date and (display_to> :curr_date or display_to is null)",
-        nativeQuery = true)
-    List<Artefact> findArtefactsBySearchUnverified(@Param("searchVal") String searchVal,
-                                                 @Param("curr_date") LocalDateTime currentDate);
+    List<Artefact> findArtefactsByCourtIdUnverified(@Param("searchVal") String searchVal,
+                                                  @Param("curr_date") LocalDateTime currentDate);
 }

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -98,9 +98,9 @@ public class PublicationService {
     public List<Artefact> findAllByCourtId(String searchValue, Boolean verified) {
         LocalDateTime currDate = LocalDateTime.now();
         if (verified) {
-            return artefactRepository.findArtefactsBySearchVerified(searchValue, currDate);
+            return artefactRepository.findArtefactsByCourtIdVerified(searchValue, currDate);
         } else {
-            return artefactRepository.findArtefactsBySearchUnverified(searchValue, currDate);
+            return artefactRepository.findArtefactsByCourtIdUnverified(searchValue, currDate);
         }
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -180,9 +180,9 @@ class PublicationServiceTest {
         artefactList.add(artefact);
         artefactList.add(artefact2);
 
-        when(artefactRepository.findArtefactsBySearchUnverified(any(), any()))
+        when(artefactRepository.findArtefactsByCourtIdVerified(any(), any()))
             .thenReturn(artefactList);
-        when(artefactRepository.findArtefactsBySearchVerified(any(), any()))
+        when(artefactRepository.findArtefactsByCourtIdUnverified(any(), any()))
             .thenReturn(artefactList);
 
         assertEquals(artefactList, publicationService.findAllByCourtId("abc", true),


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-985


### Change description ###
Amended the artefactRepository native query endpoints to return using Court ID directly instead of parsing the JSON search field as previously. This makes things much easier and allows us to return PDFs as well as JSON publications.

Also, fixed some broken integration tests that were pointing to '12345' instead of '123'. I think this may be a remnant of another ticket.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
