### PR TITLE
Pub 1420 content date dupe logic

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/PublicationTest.java
@@ -94,7 +94,7 @@ class PublicationTest {
     private static final String BLOB_PAYLOAD_URL = "https://localhost";
     private static final ListType LIST_TYPE = ListType.CIVIL_DAILY_CAUSE_LIST;
     private static final String COURT_ID = "123";
-    private static final LocalDateTime CONTENT_DATE = LocalDateTime.now();
+    private static final LocalDateTime CONTENT_DATE = LocalDateTime.now().toLocalDate().atStartOfDay();
     private static final String SEARCH_KEY_FOUND = "array-value";
     private static final String SEARCH_KEY_NOT_FOUND = "case-urn";
     private static final String SEARCH_VALUE_1 = "array-value-1";

--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationService.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.pip.model.enums.UserActions;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,7 +82,7 @@ public class PublicationService {
             + artefact.getLocationId()));
 
         applyInternalLocationId(artefact);
-
+        artefact.setContentDate(artefact.getContentDate().toLocalDate().atTime(LocalTime.MIN));
         boolean isExisting = applyExistingArtefact(artefact);
 
         String blobUrl = azureBlobService.createPayload(
@@ -104,6 +105,7 @@ public class PublicationService {
             + artefact.getLocationId()));
 
         applyInternalLocationId(artefact);
+        artefact.setContentDate(artefact.getContentDate().toLocalDate().atTime(LocalTime.MIN));
 
         boolean isExisting = applyExistingArtefact(artefact);
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -107,6 +107,7 @@ class PublicationServiceTest {
     private static final String VALIDATION_MORE_THAN_PUBLIC = "More than the public artefact has been found";
 
     private static final LocalDateTime CONTENT_DATE = LocalDateTime.now();
+    private static final LocalDateTime START_OF_TODAY_CONTENT_DATE = LocalDateTime.now().toLocalDate().atStartOfDay();
 
     private Artefact artefact;
     private Artefact artefactClassified;
@@ -435,7 +436,7 @@ class PublicationServiceTest {
             .artefactId(ARTEFACT_ID)
             .sourceArtefactId(SOURCE_ARTEFACT_ID)
             .provenance(PROVENANCE)
-            .contentDate(CONTENT_DATE)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .payload(PAYLOAD_URL)
             .search(SEARCH_VALUES)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)
@@ -449,7 +450,7 @@ class PublicationServiceTest {
             .sourceArtefactId(SOURCE_ARTEFACT_ID)
             .provenance(PROVENANCE)
             .locationId(NO_COURT_EXISTS_IN_REFERENCE_DATA)
-            .contentDate(CONTENT_DATE)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .payload(PAYLOAD_URL)
             .search(SEARCH_VALUES)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/PublicationServiceTest.java
@@ -154,7 +154,7 @@ class PublicationServiceTest {
             .sourceArtefactId(SOURCE_ARTEFACT_ID)
             .provenance(PROVENANCE)
             .locationId(PROVENANCE_ID)
-            .contentDate(CONTENT_DATE)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)
             .language(Language.ENGLISH)
             .sensitivity(Sensitivity.PUBLIC)
@@ -166,7 +166,7 @@ class PublicationServiceTest {
             .payload(PAYLOAD_URL)
             .search(SEARCH_VALUES)
             .locationId(LOCATION_ID)
-            .contentDate(CONTENT_DATE)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)
             .language(Language.ENGLISH)
             .sensitivity(Sensitivity.PUBLIC)
@@ -355,7 +355,7 @@ class PublicationServiceTest {
         artefactWithPayloadUrl.setLocationId(PROVENANCE_ID);
         artefactWithPayloadUrl.setListType(ListType.CIVIL_DAILY_CAUSE_LIST);
         artefactWithPayloadUrl.setLanguage(Language.ENGLISH);
-        artefactWithPayloadUrl.setContentDate(CONTENT_DATE);
+        artefactWithPayloadUrl.setContentDate(START_OF_TODAY_CONTENT_DATE);
 
         when(azureBlobService.createPayload(any(), eq(PAYLOAD))).thenReturn(PAYLOAD_URL);
         when(artefactRepository.save(artefactWithPayloadUrl)).thenReturn(artefactWithIdAndPayloadUrl);
@@ -372,6 +372,7 @@ class PublicationServiceTest {
             .sourceArtefactId(SOURCE_ARTEFACT_ID)
             .provenance(PROVENANCE)
             .locationId(PROVENANCE_ID)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)
             .language(Language.ENGLISH)
             .build();
@@ -379,6 +380,7 @@ class PublicationServiceTest {
         Artefact newArtefactWithId = Artefact.builder()
             .sourceArtefactId(SOURCE_ARTEFACT_ID)
             .provenance(PROVENANCE)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .locationId(PROVENANCE_ID)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)
             .language(Language.ENGLISH)
@@ -416,7 +418,7 @@ class PublicationServiceTest {
             .language(Language.ENGLISH)
             .payload(PAYLOAD_URL)
             .search(SEARCH_VALUES)
-            .contentDate(CONTENT_DATE)
+            .contentDate(START_OF_TODAY_CONTENT_DATE)
             .listType(ListType.CIVIL_DAILY_CAUSE_LIST)
             .build();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1420


### Change description ###
The reason for the dupe logic not working is pubs being fed in with very slightly different content dates (S&L populates content date from upload time). 

This means that multiple lists of the same type will appear if this continues. 

After discussion with Prof. Craven, it has been decided that content dates need not ever include a time, so all content dates are now altered to the start of day at the point of ingestion to reflect this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
