### PR TITLE
CVE-2022-31197 Update postgresql dependency to 42.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   implementation group: 'com.azure', name: 'azure-data-tables', version: '12.1.2'
   implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '1.1.1'
   implementation 'com.networknt:json-schema-validator:1.0.64'
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Update postgresql dependency to 42.4.1 to fix CVE-2022-31197

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```