### PR TITLE
PUB-1607 Return all date fields from Artefact in UTC format

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pip/data/management/models/publication/Artefact.java
+++ b/src/main/java/uk/gov/hmcts/reform/pip/data/management/models/publication/Artefact.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.pip.data.management.models.publication;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -78,11 +79,13 @@ public class Artefact {
     /**
      * Date / Time from which the publication will be displayed.
      */
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     private LocalDateTime displayFrom;
 
     /**
      * Date / Time until which the publication will be displayed.
      */
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     private LocalDateTime displayTo;
 
     /**
@@ -99,6 +102,7 @@ public class Artefact {
     /**
      * Date / Time the publication is referring to.
      */
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     private LocalDateTime contentDate;
 
     /**


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1607

### Change description ###

Return all date fields from Artefact in UTC format so the front end will show the list content date correctly during daylight saving

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
