### PR TITLE
PUB-1598 Upgrade HMCTS logging components to latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ dependencies {
   implementation group: 'com.azure', name: 'azure-data-tables', version: '12.3.5'
   implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '1.2.1'
   implementation 'com.networknt:json-schema-validator:1.0.73'
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.1'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.5.5'

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ dependencyCheck {
 }
 
 ext {
-  reformLoggingVersion = "5.1.9"
+  reformLoggingVersion = "6.0.1"
 }
 
 dependencies {
@@ -176,6 +176,7 @@ dependencies {
   implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
+  implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.2'
   implementation group: 'com.azure', name: 'azure-data-tables', version: '12.3.5'
   implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '1.2.1'
   implementation 'com.networknt:json-schema-validator:1.0.73'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-1598

### Change description ###

Upgrade HMCTS logging components to latest version. 

We have to bring a new dependency "logstash-logback-encoder" into the project because java-logging-appinsights are using an Appender from logstash in their XML config. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
