### PR TITLE
PUB-2105 Make SJP press list sub-address and sub-individual details fields non-mandatory

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/lists/PublicationSjpPressTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pip/data/management/controllers/lists/PublicationSjpPressTest.java
@@ -135,8 +135,8 @@ class PublicationSjpPressTest {
             );
 
             assertTrue(
-                exceptionResponse.getMessage().contains("individualSurname"),
-                "Individual Surname is not displayed in the exception response"
+                exceptionResponse.getMessage().contains("dateOfBirth"),
+                "Date of birth is not displayed in the exception response"
             );
         }
     }

--- a/src/functionalTest/resources/data/sjp-press-list/sjpPressListInvalid.json
+++ b/src/functionalTest/resources/data/sjp-press-list/sjpPressListInvalid.json
@@ -20,7 +20,6 @@
                             "partyRole": "ACCUSED",
                             "individualDetails": {
                               "individualForenames": "This is a forename",
-                              "dateOfBirth": "01/01/1800",
                               "age": 50,
                               "address": {
                                 "county": "County A",

--- a/src/main/resources/schemas/single_justice_procedure_press.json
+++ b/src/main/resources/schemas/single_justice_procedure_press.json
@@ -209,8 +209,7 @@
                                               "type": "object",
                                               "required": [
                                                 "dateOfBirth",
-                                                "age",
-                                                "address"
+                                                "age"
                                               ],
                                               "properties": {
                                                 "title": {

--- a/src/main/resources/schemas/single_justice_procedure_press.json
+++ b/src/main/resources/schemas/single_justice_procedure_press.json
@@ -208,8 +208,6 @@
                                               "description": "Individual Details",
                                               "type": "object",
                                               "required": [
-                                                "individualForenames",
-                                                "individualSurname",
                                                 "dateOfBirth",
                                                 "age",
                                                 "address"
@@ -282,12 +280,7 @@
                                                   "$id": "#root/courtLists/courtList/courtRoom/session/sittings/items/hearing/items/individualDetails/address",
                                                   "title": "Address",
                                                   "description": "Party Address",
-                                                  "$ref": "#/definitions/address",
-                                                  "required": [
-                                                    "town",
-                                                    "county",
-                                                    "postCode"
-                                                  ]
+                                                  "$ref": "#/definitions/address"
                                                 }
                                               }
                                             },
@@ -315,12 +308,7 @@
                                                   "$id": "#root/courtLists/courtList/courtRoom/session/sittings/items/hearing/items/organisationDetails/organisationAddress",
                                                   "title": "Organisation Address",
                                                   "description": "Party Address",
-                                                  "$ref": "#/definitions/address",
-                                                  "required": [
-                                                    "town",
-                                                    "county",
-                                                    "postCode"
-                                                  ]
+                                                  "$ref": "#/definitions/address"
                                                 }
                                               }
                                             }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPressListTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPressListTest.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest(classes = {Application.class, AzureBlobConfigurationTestConfiguration.class})
@@ -39,7 +40,8 @@ class SjpPressListTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String SJP_PRESS_LIST_VALID_JSON = "mocks/sjp-press-list/sjpPressList.json";
-    private static final String SJP_PRESS_INVALID_MESSAGE = "Invalid sjp press";
+    private static final String SJP_PRESS_INVALID_MESSAGE = "Invalid SJP press";
+    private static final String SJP_PRESS_VALID_MESSAGE = "Exception should not be thrown for SJP press";
 
     private static final String COURT_LIST_SCHEMA = "courtLists";
     private static final String COURT_HOUSE_SCHEMA = "courtHouse";
@@ -338,9 +340,8 @@ class SjpPressListTest {
                 .remove("individualForenames");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -358,9 +359,8 @@ class SjpPressListTest {
                 .remove("individualSurname");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -438,9 +438,8 @@ class SjpPressListTest {
                 .get(ADDRESS_SCHEMA)).remove("town");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -458,9 +457,8 @@ class SjpPressListTest {
                 .get(ADDRESS_SCHEMA)).remove("county");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -478,9 +476,8 @@ class SjpPressListTest {
                 .get(ADDRESS_SCHEMA)).remove("postCode");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -518,9 +515,8 @@ class SjpPressListTest {
                 .get(ORGANISATION_ADDRESS_SCHEMA)).remove("town");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -538,9 +534,8 @@ class SjpPressListTest {
                 .get(ORGANISATION_ADDRESS_SCHEMA)).remove("county");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
@@ -558,9 +553,8 @@ class SjpPressListTest {
                 .get(ORGANISATION_ADDRESS_SCHEMA)).remove("postCode");
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPressListTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPressListTest.java
@@ -327,7 +327,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenIndividualForenamesForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenIndividualForenamesForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -346,7 +346,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenIndividualSurnameForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenIndividualSurnameForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -405,7 +405,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenAddressForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenAddressForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -418,14 +418,13 @@ class SjpPressListTest {
                 .remove(ADDRESS_SCHEMA);
 
             String listJson = node.toString();
-            assertThrows(PayloadValidationException.class, () ->
-                             validationService.validateBody(listJson, headerGroup),
-                         SJP_PRESS_INVALID_MESSAGE);
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
         }
     }
 
     @Test
-    void testValidateWithErrorWhenTownForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenTownForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -444,7 +443,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenCountryForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenCountryForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -463,7 +462,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenPostCodeForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenPostCodeForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -502,7 +501,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenOrganisationTownForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenOrganisationTownForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -521,7 +520,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenOrganisationCountryForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenOrganisationCountryForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -540,7 +539,7 @@ class SjpPressListTest {
     }
 
     @Test
-    void testValidateWithErrorWhenOrganisationPostCodeForAccusedMissingInSjpPressList() throws IOException {
+    void testValidateWithSuccessWhenOrganisationPostCodeForAccusedMissingInSjpPressList() throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);

--- a/src/test/resources/mocks/sjp-press-list/sjpPressList.json
+++ b/src/test/resources/mocks/sjp-press-list/sjpPressList.json
@@ -19,12 +19,10 @@
                           {
                             "partyRole": "ACCUSED",
                             "individualDetails": {
-                              "individualForenames": "This is a forename",
                               "individualSurname": "This is a surname",
                               "dateOfBirth": "01/01/1800",
                               "age": 50,
                               "address": {
-                                "county": "County A",
                                 "town": "Month A",
                                 "postCode": "AA1 AA1",
                                 "line": [
@@ -32,8 +30,7 @@
                                   "Address Line 2"
                                 ]
                               },
-                              "title": "This is a title",
-                              "individualMiddleName": "This is a middle name"
+                              "title": "This is a title"
                             }
                           },
                           {
@@ -65,11 +62,7 @@
                               "organisationAddress": {
                                 "county": "County A",
                                 "town": "Month A",
-                                "postCode": "AA1 AA1",
-                                "line": [
-                                  "Address Line 1",
-                                  "Address Line 2"
-                                ]
+                                "postCode": "AA1 AA1"
                               }
                             }
                           },


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2105

### Change description ###

Make SJP press list sub-address and sub-individual details fields non-mandatory

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
