### PR TITLE
PUB-2119 - Dependency updates + suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 plugins {
   id 'application'
   id 'checkstyle'
-  id 'io.spring.dependency-management' version '1.1.0'
+  id 'io.spring.dependency-management' version '1.1.2'
   id 'jacoco'
-  id 'org.springframework.boot' version '3.0.9'
+  id 'org.springframework.boot' version '3.1.2'
   id 'org.owasp.dependencycheck' version '8.3.1'
-  id 'org.sonarqube' version '4.2.1.3168'
+  id 'org.sonarqube' version '4.3.0.3225'
   id 'pmd'
-  id 'org.flywaydb.flyway' version '9.20.0'
+  id 'org.flywaydb.flyway' version '9.21.1'
   id 'io.freefair.lombok' version '8.1.0'
-  id 'org.jetbrains.kotlin.jvm' version '1.8.22'
+  id 'org.jetbrains.kotlin.jvm' version '1.9.0'
 }
 
 apply plugin: 'org.owasp.dependencycheck'
@@ -180,30 +180,30 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-  implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.22.3'
+  implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.23.0'
   implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.8.0'
   implementation group: 'com.vladmihalcea', name: 'hibernate-types-60', version: '2.21.1'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
-  implementation group: 'com.google.guava', name: 'guava', version: '32.1.1-jre'
+  implementation group: 'com.google.guava', name: 'guava', version: '32.1.2-jre'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
-  implementation group: 'com.azure', name: 'azure-data-tables', version: '12.3.12'
-  implementation 'com.networknt:json-schema-validator:1.0.83'
+  implementation group: 'com.azure', name: 'azure-data-tables', version: '12.3.13'
+  implementation 'com.networknt:json-schema-validator:1.0.86'
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
   implementation group: 'com.github.hmcts', name: 'pip-data-models', version: '2.1.2'
   implementation 'org.springframework.boot:spring-boot-starter-validation'
   implementation 'org.springframework.boot:spring-boot-starter-jdbc'
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-  implementation 'com.azure.spring:spring-cloud-azure-starter-active-directory:5.2.0'
+  implementation 'com.azure.spring:spring-cloud-azure-starter-active-directory:5.3.0'
   implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
   implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-  implementation 'com.opencsv:opencsv:5.7.1'
+  implementation 'com.opencsv:opencsv:5.8'
   implementation 'org.springframework.boot:spring-boot-starter-webflux'
   implementation("com.squareup.okhttp3:okhttp:4.11.0")
 
   // Include Flyway for database migrations
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.19.4'
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.21.1'
 
   // Force upgrade snakeyaml version for CVE-2022-38752
   implementation( group: 'org.yaml', name: 'snakeyaml').version {
@@ -212,7 +212,7 @@ dependencies {
 
   testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
   testImplementation "io.zonky.test:embedded-database-spring-test:2.3.0"
-  testImplementation(platform('org.junit:junit-bom:5.9.3'))
+  testImplementation(platform('org.junit:junit-bom:5.10.0'))
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/charts/pip-data-management/Chart.yaml
+++ b/charts/pip-data-management/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS PIP Team
 dependencies:
   - name: java
-    version: 4.1.4
+    version: 4.1.5
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-    <notes><![CDATA[file name: spring-cloud-azure-starter-active-directory-5.2.0.jar]]></notes>
-    <packageUrl regex="true">^pkg:maven/com.azure.spring/spring-cloud-azure-starter-active-directory@5.2.0</packageUrl>
+    <notes><![CDATA[file name: spring-cloud-azure-starter-active-directory-5.3.0.jar]]></notes>
+    <packageUrl regex="true">^pkg:maven/com.azure.spring/spring-cloud-azure-starter-active-directory@5.3.0</packageUrl>
     <cve>CVE-2021-42306</cve>
   </suppress>
   <suppress>
     <notes>The vulnerability exists in the latest version of lib too. Need to wait for new version with the fix</notes>
-    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.3</packageUrl>
+    <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2</packageUrl>
     <cve>CVE-2023-35116</cve>
-  </suppress>
-  <suppress>
-    <notes>Pull in by spring boot. The latest version of spring boot v3.1.1 is still using netty v4.1.93 where the vulnerability still exists</notes>
-    <packageUrl regex="true">^pkg:maven/io.netty/netty-.*$</packageUrl>
-    <cve>CVE-2023-34462</cve>
   </suppress>
   <suppress>
     <notes>Already on latest version of okhttp</notes>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
-
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2119

### Change description ###

Dependency updates + suppression updates

Spring Dependency Management to 1.1.2
Spring Boot to 3.1.2
Sonarqube to 4.3.0.3225
Flyway plugin and core to 9.21.1
Active Directory starter to 5.3.0
jUnit to 5.10.0
Chart version to 4.1.5
Gradle version to 8.2.1
Kotlin JVM to 1.9.0
Guava to 32.1.2-jre
Azure storage blob to 12.23.0
Azure data tables to 12.23.0
json-schema-validator to 1.0.86
Opencsv to 5.8

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
