### PR TITLE
PUB-2552 - Update regex for SJP lists

### DIFF
--- a/src/main/resources/schemas/master_schema.json
+++ b/src/main/resources/schemas/master_schema.json
@@ -16,12 +16,12 @@
         "town": {
           "title": "Town",
           "type": "string",
-          "pattern": "^(?!.*<[^>]+>).*$"
+          "pattern": "^(?!(.|\\r|\\n)*<[^>]+>)(.|\\r|\\n)*$"
         },
         "county": {
           "title": "County",
           "type": "string",
-          "pattern": "^(?!.*<[^>]+>).*$"
+          "pattern": "^(?!(.|\\r|\\n)*<[^>]+>)(.|\\r|\\n)*$"
         },
         "postCode": {
           "title": "Address Postcode",

--- a/src/main/resources/schemas/single_justice_procedure_press.json
+++ b/src/main/resources/schemas/single_justice_procedure_press.json
@@ -26,7 +26,7 @@
           "examples": [
             "Cambridge"
           ],
-          "pattern": "^(?!.*<[^>]+>).*$"
+          "pattern": "^(?!(.|\\r|\\n)*<[^>]+>)(.|\\r|\\n)*$"
         },
         "county": {
           "title": "County",
@@ -36,7 +36,7 @@
           "examples": [
             "Cambridgeshire"
           ],
-          "pattern": "^(?!.*<[^>]+>).*$"
+          "pattern": "^(?!(.|\\r|\\n)*<[^>]+>)(.|\\r|\\n)*$"
         },
         "postCode": {
           "title": "Address Postcode",

--- a/src/main/resources/schemas/single_justice_procedure_public.json
+++ b/src/main/resources/schemas/single_justice_procedure_public.json
@@ -145,7 +145,7 @@
                                                     "A"
                                                   ],
                                                   "default": "",
-                                                  "pattern": "^[a-zA-Z]$"
+                                                  "pattern": "^.?$"
                                                 },
                                                 "individualSurname": {
                                                   "description": "Surname of party",

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/ValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/ValidationServiceTest.java
@@ -251,7 +251,9 @@ class ValidationServiceTest {
                              validationService.validateBody(text, headerGroup),
                          "Valid JSON string marked as not valid");
 
-            assertEquals("$.venue.venueAddress.town: does not match the regex pattern ^(?!.*<[^>]+>).*$",
+            assertEquals("$.venue.venueAddress.town: does not match the regex pattern ^(?!.*<[^>]+>).*$, "
+                             + "$.venue.venueAddress.town: does not match the regex pattern ^(?!(.|\\r|\\n)*<[^>]+>)"
+                             + "(.|\\r|\\n)*$",
                          payloadValidationException.getMessage(),
                          "JSON Payload message does not match expected exception");
         } catch (IOException exception) {

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPressListTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPressListTest.java
@@ -671,4 +671,27 @@ class SjpPressListTest {
                                SJP_PRESS_VALID_MESSAGE);
         }
     }
+
+    @Test
+    void testValidateWithoutErrorWhenTownAndCountyContainNewLineCharacters() throws IOException {
+        try (InputStream jsonInput = this.getClass().getClassLoader()
+            .getResourceAsStream(SJP_PRESS_LIST_VALID_JSON)) {
+            String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
+
+            JsonNode node = OBJECT_MAPPER.readValue(text, JsonNode.class);
+
+            ObjectNode addressNode = (ObjectNode) node.get(COURT_LIST_SCHEMA).get(0).get(COURT_HOUSE_SCHEMA)
+                .get(COURT_ROOM_SCHEMA).get(0).get(SESSION_SCHEMA).get(0)
+                .get(SITTINGS_SCHEMA).get(0).get(HEARING_SCHEMA).get(0)
+                .get(PARTY_SCHEMA).get(0).get(INDIVIDUAL_DETAILS_SCHEMA)
+                .get(ADDRESS_SCHEMA);
+
+            addressNode.put("town", "A\nB");
+            addressNode.put("county", "C\rD");
+
+            String listJson = node.toString();
+            assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
+                               SJP_PRESS_VALID_MESSAGE);
+        }
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPublicListTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pip/data/management/service/schemavalidation/SjpPublicListTest.java
@@ -478,7 +478,7 @@ class SjpPublicListTest {
 
             String listJson = node.toString().replace(
                 "\"individualForenames\":\"A\"",
-                "\"individualForenames\":\"ABC\""
+                "\"individualForenames\":\"AB\""
             );
             assertThrows(PayloadValidationException.class, () ->
                              validationService.validateBody(listJson, headerGroup),
@@ -487,8 +487,9 @@ class SjpPublicListTest {
         }
     }
 
-    @Test
-    void testValidateWithSuccessWhenForenameForAccusedIsLowerCaseInitial() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = {"Z", "a", ".", "-", ""})
+    void testValidateWithSuccessWhenForenameForAccusedIsEmptyOrASingleCharacter(String forename) throws IOException {
         try (InputStream jsonInput = this.getClass().getClassLoader()
             .getResourceAsStream(SJP_PUBLIC_LIST_VALID_JSON)) {
             String text = new String(jsonInput.readAllBytes(), StandardCharsets.UTF_8);
@@ -498,7 +499,7 @@ class SjpPublicListTest {
 
             String listJson = node.toString().replace(
                 "\"individualForenames\":\"A\"",
-                "\"individualForenames\":\"a\""
+                "\"individualForenames\":\"" + forename + "\""
             );
             assertDoesNotThrow(() -> validationService.validateBody(listJson, headerGroup),
                                SJP_PUBLIC_VALID_MESSAGE);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PUB-2552

### Change description ###

Update regex for SJP lists:
- SJP Public List forename can be empty or a single character only
- SJP Press List town and county can contain new line characters

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
